### PR TITLE
fix print.js: Not showing default template if built with beta builder

### DIFF
--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -420,6 +420,9 @@ frappe.ui.form.PrintView = class {
 			params.append("letterhead", letterhead);
 		}
 		iframe.prop("src", `/printpreview?${params.toString()}`);
+		iframe.on("load", ()=>{
+			iframe.height(iframe.get(0).contentWindow.document.body.scrollHeight);
+		})
 	}
 
 	setup_print_format_dom(out, $print_format) {


### PR DESCRIPTION
Commits on Aug 22, 2023

fix print.js: Not showing default template if built with beta builder. Please backport this to latest v14. Glad to help if this needs a unit test.

Closes #22159

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
